### PR TITLE
externpro 26.01.1-41-g49be750

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,0 +1,4 @@
+{
+  "message": "xpro version 3.14.0.6 tag",
+  "tag": "xpv3.14.0.6"
+}

--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,0 @@
-tag: xpv3.14.0.5
-message: "xpro version 3.14.0.5 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,11 +14,15 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
-    secrets: inherit
+    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01.1
+    secrets:
+      automation_token: ${{ secrets.GHCR_TOKEN }}
+    with: {}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01.1
     secrets: inherit
+    with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01.1
     secrets: inherit
+    with: {}

--- a/.github/workflows/xpinit.yml
+++ b/.github/workflows/xpinit.yml
@@ -1,0 +1,12 @@
+name: xpInit externpro
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+on:
+  workflow_dispatch:
+jobs:
+  init:
+    uses: externpro/externpro/.github/workflows/init-externpro.yml@main
+    secrets:
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01.1
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01.1
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
-      workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.1.3...3.31)
-set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES .devcontainer/cmake/xproinc.cmake)
+cmake_minimum_required(VERSION 3.1.3...4.3)
 project(protobuf_root)
 add_subdirectory(cmake)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,7 @@
   "include": [
     ".devcontainer/cmake/presets/xpLinuxNinja.json",
     ".devcontainer/cmake/presets/xpDarwinNinja.json",
-    ".devcontainer/cmake/presets/xpWindowsVs2022.json"
+    ".devcontainer/cmake/presets/xpMswVs2022.json",
+    ".devcontainer/cmake/presets/xpMswVs2026.json"
   ]
 }

--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -6,7 +6,7 @@
       "hidden": true,
       "binaryDir": "${sourceDir}/_bld-${presetName}",
       "cacheVariables": {
-        "XP_NAMESPACE": "xpro"
+        "CMAKE_EXPERIMENTAL_GENERATE_SBOM": "ca494ed3-b261-4205-a01f-603c95e4cae0"
       }
     }
   ],

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -56,8 +56,13 @@ cmake_dependent_option(protobuf_MSVC_STATIC_RUNTIME "Link static runtime librari
   "NOT protobuf_BUILD_SHARED_LIBS" OFF)
 set(protobuf_WITH_ZLIB_DEFAULT ON)
 option(protobuf_WITH_ZLIB "Build with zlib support" ${protobuf_WITH_ZLIB_DEFAULT})
+if(DEFINED CMAKE_DEBUG_POSTFIX)
+  set(protobuf_DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX}
+    CACHE STRING "Default debug postfix")
+else()
 set(protobuf_DEBUG_POSTFIX "d"
   CACHE STRING "Default debug postfix")
+endif()
 mark_as_advanced(protobuf_DEBUG_POSTFIX)
 # User options
 include(protobuf-options.cmake)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Minimum CMake required
-cmake_minimum_required(VERSION 3.1.3...3.31)
+cmake_minimum_required(VERSION 3.1.3...4.3)
 
 if(protobuf_VERBOSE)
   message(STATUS "Protocol Buffers Configuring...")
@@ -119,32 +119,6 @@ if(protobuf_VERBOSE)
   message(STATUS "  Version     : ${protobuf_VERSION} (${protobuf_VERSION_STRING})")
   message(STATUS "  Contact     : ${protobuf_CONTACT}")
   message(STATUS "]")
-endif()
-
-if(DEFINED XP_NAMESPACE)
-  set(CMAKE_NAMESPACE ${XP_NAMESPACE})
-  string(JOIN "\n" EXT1
-    "set(FPHSA_NAME_MISMATCHED TRUE) # FIND_PACKAGE_HANDLE_STANDARD_ARGS NAME_MISMATCHED"
-    "set(protobuf_MODULE_COMPATIBLE ON) # necessary for GENERATE_PROTOBUF_CPP"
-    ""
-    )
-  string(JOIN "\n" EXT3
-    "set(PROTOBUF_PROTOC_EXECUTABLE ${CMAKE_NAMESPACE}::protoc) # TRICKY: match name in -module.cmake"
-    "get_target_property(PROTOBUF_INCLUDE_DIR ${CMAKE_NAMESPACE}::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)"
-    "list(APPEND reqVars PROTOBUF_INCLUDE_DIR PROTOBUF_PROTOC_EXECUTABLE)"
-    ""
-    )
-  xpExternPackage(REPO_NAME protobuf NAMESPACE ${XP_NAMESPACE} ALIAS_NAMESPACE protobuf
-    TARGETS_FILE protobuf-config EXE protoc LIBRARIES libprotobuf
-    BASE ${protobuf_BASE_TAG} XPDIFF "patch" DEPS zlib
-    WEB "https://developers.google.com/protocol-buffers/" UPSTREAM "github.com/protocolbuffers/protobuf"
-    DESC "language-neutral, platform-neutral extensible mechanism for serializing structured data"
-    LICENSE "[BSD-3-Clause](https://github.com/protocolbuffers/protobuf/blob/v3.14.0/LICENSE 'BSD 3-Clause New or Revised License')"
-    )
-  set(CMAKE_OPT_INSTALL FALSE)
-else()
-  set(CMAKE_NAMESPACE protobuf)
-  set(CMAKE_OPT_INSTALL TRUE)
 endif()
 
 add_definitions(-DGOOGLE_PROTOBUF_CMAKE_BUILD)
@@ -316,6 +290,30 @@ endif (protobuf_BUILD_TESTS)
 if (protobuf_BUILD_CONFORMANCE)
   include(conformance.cmake)
 endif (protobuf_BUILD_CONFORMANCE)
+
+if(COMMAND xpExternPackage)
+  string(JOIN "\n" EXT1
+    "set(FPHSA_NAME_MISMATCHED TRUE) # FIND_PACKAGE_HANDLE_STANDARD_ARGS NAME_MISMATCHED"
+    "set(protobuf_MODULE_COMPATIBLE ON) # necessary for GENERATE_PROTOBUF_CPP"
+    ""
+    )
+  string(JOIN "\n" EXT3
+    "set(PROTOBUF_PROTOC_EXECUTABLE ${PROJECT_NAME}::protoc) # TRICKY: match name in -module.cmake"
+    "get_target_property(PROTOBUF_INCLUDE_DIR ${PROJECT_NAME}::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)"
+    "list(APPEND reqVars PROTOBUF_INCLUDE_DIR PROTOBUF_PROTOC_EXECUTABLE)"
+    ""
+    )
+  xpExternPackage(REPO_NAME protobuf TARGETS_FILE protobuf-config-orig EXPORT protobuf-targets
+    EXE protoc LIBRARIES libprotobuf FIND_XPRO_CMAKE
+    BASE ${protobuf_BASE_TAG} XPDIFF "patch"
+    WEB "https://developers.google.com/protocol-buffers/" UPSTREAM "github.com/protocolbuffers/protobuf"
+    DESC "language-neutral, platform-neutral extensible mechanism for serializing structured data"
+    LICENSE "[BSD-3-Clause](https://github.com/protocolbuffers/protobuf/blob/v3.14.0/LICENSE 'BSD 3-Clause New or Revised License')"
+    )
+  set(CMAKE_OPT_INSTALL FALSE)
+else()
+  set(CMAKE_OPT_INSTALL TRUE)
+endif()
 
 include(install.cmake)
 

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -116,7 +116,7 @@ endif()
 mark_as_advanced(CMAKE_INSTALL_CMAKEDIR)
 
 configure_file(protobuf-config.cmake.in
-  ${CMAKE_INSTALL_CMAKEDIR}/protobuf-config.cmake @ONLY)
+  ${CMAKE_INSTALL_CMAKEDIR}/protobuf-config-orig.cmake @ONLY)
 configure_file(protobuf-config-version.cmake.in
   ${CMAKE_INSTALL_CMAKEDIR}/protobuf-config-version.cmake @ONLY)
 configure_file(protobuf-module.cmake.in

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -128,19 +128,19 @@ configure_file(protobuf-options.cmake
 
 if (protobuf_BUILD_PROTOC_BINARIES)
   export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
-    NAMESPACE ${CMAKE_NAMESPACE}::
+    NAMESPACE protobuf::
     FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
   )
 else (protobuf_BUILD_PROTOC_BINARIES)
   export(TARGETS libprotobuf-lite libprotobuf
-    NAMESPACE ${CMAKE_NAMESPACE}::
+    NAMESPACE protobuf::
     FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
   )
 endif (protobuf_BUILD_PROTOC_BINARIES)
 
 install(EXPORT protobuf-targets
   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
-  NAMESPACE ${CMAKE_NAMESPACE}::
+  NAMESPACE protobuf::
   COMPONENT protobuf-export)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_CMAKEDIR}/

--- a/cmake/libprotobuf-lite.cmake
+++ b/cmake/libprotobuf-lite.cmake
@@ -81,5 +81,5 @@ endif()
 set_target_properties(libprotobuf-lite PROPERTIES
     VERSION ${protobuf_VERSION}
     OUTPUT_NAME ${LIB_PREFIX}protobuf-lite
-    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
-add_library(${CMAKE_NAMESPACE}::libprotobuf-lite ALIAS libprotobuf-lite)
+    DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")
+add_library(protobuf::libprotobuf-lite ALIAS libprotobuf-lite)

--- a/cmake/libprotobuf.cmake
+++ b/cmake/libprotobuf.cmake
@@ -133,5 +133,5 @@ endif()
 set_target_properties(libprotobuf PROPERTIES
     VERSION ${protobuf_VERSION}
     OUTPUT_NAME ${LIB_PREFIX}protobuf
-    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
-add_library(${CMAKE_NAMESPACE}::libprotobuf ALIAS libprotobuf)
+    DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")
+add_library(protobuf::libprotobuf ALIAS libprotobuf)

--- a/cmake/libprotoc.cmake
+++ b/cmake/libprotoc.cmake
@@ -177,5 +177,6 @@ set_target_properties(libprotoc PROPERTIES
     COMPILE_DEFINITIONS LIBPROTOC_EXPORTS
     VERSION ${protobuf_VERSION}
     OUTPUT_NAME ${LIB_PREFIX}protoc
-    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
-add_library(${CMAKE_NAMESPACE}::libprotoc ALIAS libprotoc)
+    DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")
+add_library(protobuf::libprotoc ALIAS libprotoc)
+

--- a/cmake/protobuf-config.cmake.in
+++ b/cmake/protobuf-config.cmake.in
@@ -129,9 +129,9 @@ function(protobuf_generate)
 
     add_custom_command(
       OUTPUT ${_generated_srcs}
-      COMMAND  @CMAKE_NAMESPACE@::protoc
+      COMMAND  protobuf::protoc
       ARGS --${protobuf_generate_LANGUAGE}_out ${_dll_export_decl}${protobuf_generate_PROTOC_OUT_DIR} ${_plugin} ${_protobuf_include_path} ${_abs_file}
-      DEPENDS ${_abs_file} @CMAKE_NAMESPACE@::protoc
+      DEPENDS ${_abs_file} protobuf::protoc
       COMMENT "Running ${protobuf_generate_LANGUAGE} protocol buffer compiler on ${_proto}"
       VERBATIM )
   endforeach()

--- a/cmake/protobuf-module.cmake.in
+++ b/cmake/protobuf-module.cmake.in
@@ -95,13 +95,13 @@ function(_protobuf_find_libraries name filename)
     # Honor cache entry used by CMake 3.5 and lower.
     set(${name}_LIBRARIES "${${name}_LIBRARY}" PARENT_SCOPE)
   else()
-    get_target_property(${name}_LIBRARY_RELEASE @CMAKE_NAMESPACE@::lib${filename}
+    get_target_property(${name}_LIBRARY_RELEASE protobuf::lib${filename}
       LOCATION_RELEASE)
-    get_target_property(${name}_LIBRARY_RELWITHDEBINFO @CMAKE_NAMESPACE@::lib${filename}
+    get_target_property(${name}_LIBRARY_RELWITHDEBINFO protobuf::lib${filename}
       LOCATION_RELWITHDEBINFO)
-    get_target_property(${name}_LIBRARY_MINSIZEREL @CMAKE_NAMESPACE@::lib${filename}
+    get_target_property(${name}_LIBRARY_MINSIZEREL protobuf::lib${filename}
       LOCATION_MINSIZEREL)
-    get_target_property(${name}_LIBRARY_DEBUG @CMAKE_NAMESPACE@::lib${filename}
+    get_target_property(${name}_LIBRARY_DEBUG protobuf::lib${filename}
       LOCATION_DEBUG)
 
     select_library_configurations(${name})
@@ -144,26 +144,26 @@ if(UNIX)
 endif()
 
 # Set the include directory
-get_target_property(Protobuf_INCLUDE_DIRS @CMAKE_NAMESPACE@::libprotobuf
+get_target_property(Protobuf_INCLUDE_DIRS protobuf::libprotobuf
   INTERFACE_INCLUDE_DIRECTORIES)
 
 # Set the protoc Executable
-get_target_property(Protobuf_PROTOC_EXECUTABLE @CMAKE_NAMESPACE@::protoc
+get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
   IMPORTED_LOCATION_RELEASE)
 if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
-  get_target_property(Protobuf_PROTOC_EXECUTABLE @CMAKE_NAMESPACE@::protoc
+  get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
     IMPORTED_LOCATION_RELWITHDEBINFO)
 endif()
 if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
-  get_target_property(Protobuf_PROTOC_EXECUTABLE @CMAKE_NAMESPACE@::protoc
+  get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
     IMPORTED_LOCATION_MINSIZEREL)
 endif()
 if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
-  get_target_property(Protobuf_PROTOC_EXECUTABLE @CMAKE_NAMESPACE@::protoc
+  get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
     IMPORTED_LOCATION_DEBUG)
 endif()
 if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
-  get_target_property(Protobuf_PROTOC_EXECUTABLE @CMAKE_NAMESPACE@::protoc
+  get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc
     IMPORTED_LOCATION_NOCONFIG)
 endif()
 

--- a/cmake/protoc.cmake
+++ b/cmake/protoc.cmake
@@ -10,7 +10,7 @@ endif()
 
 add_executable(protoc ${protoc_files} ${protoc_rc_files})
 target_link_libraries(protoc libprotoc libprotobuf)
-add_executable(${CMAKE_NAMESPACE}::protoc ALIAS protoc)
+add_executable(protobuf::protoc ALIAS protoc)
 
 set_target_properties(protoc PROPERTIES
-    DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
+    DEBUG_POSTFIX "${protobuf_DEBUG_POSTFIX}")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach(example add_person list_people)
     target_include_directories(${executable_name} PUBLIC ${PROTOBUF_INCLUDE_DIRS})
     target_link_libraries(${executable_name} ${PROTOBUF_LIBRARIES})
   else()
-    target_link_libraries(${executable_name} ${CMAKE_NAMESPACE}::libprotobuf)
+    target_link_libraries(${executable_name} protobuf::libprotobuf)
     protobuf_generate(TARGET ${executable_name})
   endif()
 

--- a/xprodeps.md
+++ b/xprodeps.md
@@ -3,7 +3,7 @@
 |project|license [^_l]|description [dependencies]|version|source|diff [^_d]|
 |-------|-------------|--------------------------|-------|------|----------|
 |<a id='protobuf' />[protobuf](https://developers.google.com/protocol-buffers/)|[BSD-3-Clause](https://github.com/protocolbuffers/protobuf/blob/v3.14.0/LICENSE 'BSD 3-Clause New or Revised License')|language-neutral, platform-neutral extensible mechanism for serializing structured data [deps: _zlib_]| |[upstream](https://github.com/protocolbuffers/protobuf 'github.com/protocolbuffers/protobuf')|  [patch]|
-|<a id='zlib' />[zlib](https://zlib.net 'zlib website')|[permissive](https://zlib.net/zlib_license.html 'zlib/libpng license, see https://en.wikipedia.org/wiki/Zlib_License')|compression library|[xpv1.3.1.4](https://github.com/externpro/zlib/releases/tag/xpv1.3.1.4 'release')|[repo](https://github.com/externpro/zlib 'github.com/externpro/zlib') [upstream](https://github.com/madler/zlib 'github.com/madler/zlib')|[diff](https://github.com/externpro/zlib/compare/v1.3.1...xpv1.3.1.4 'github.com/externpro/zlib/compare/v1.3.1...xpv1.3.1.4') [patch]|
+|<a id='zlib' />[zlib](https://zlib.net/ 'zlib website')|[Zlib](https://zlib.net/zlib_license.html 'zlib/libpng license, see https://en.wikipedia.org/wiki/Zlib_License')|a general-purpose lossless data-compression library|[xpv1.3.2.1](https://github.com/externpro/zlib/releases/tag/xpv1.3.2.1 'release')|[repo](https://github.com/externpro/zlib 'github.com/externpro/zlib') [upstream](https://github.com/madler/zlib 'github.com/madler/zlib')|[diff](https://github.com/externpro/zlib/compare/v1.3.2...xpv1.3.2.1 'github.com/externpro/zlib/compare/v1.3.2...xpv1.3.2.1') [patch]|
 
 ![deps](xprodeps.svg 'dependencies')
 


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-41-g49be750`

## Changes

- Updated `.devcontainer` to externpro `26.01.1-41-g49be750`
- Previous HEAD: `0ac4bac86f2f25110dcf941fb94820bd79c061ec`
- New HEAD: `49be7504e19dbad58d8166f98ef0c14b942ea58b`
- Updated dependency files
  - Files:
    - `xprodeps.md`
- Created `.github/release-tag.json` (tag: `xpv3.14.0.6`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv3.14.0.6\`
- Updated caller workflows to match templates
- CMakePresets.json review needed
  - See details below

### Workflow Update Report

- ✓ xpbuild.yml: Synced from template
- ✓ xpinit.yml: Created new workflow from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

### CMakePresets.json

- Auto-fix: replaced `.devcontainer/cmake/presets/xpWindowsVs2022.json` include and staged `CMakePresets.json`

---

*This PR was created automatically by GitHub Actions*
